### PR TITLE
To make it work on portal integrations

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -103,7 +103,7 @@ export default class PostRPCClient {
 	 * @return {Window}
 	 */
 	get parent() {
-		return window.opener;
+		return window.opener || window.parent;
 	}
 
 	/**
@@ -274,7 +274,7 @@ export default class PostRPCClient {
 			resolve: resolve,
 			reject: reject
 		});
-		this.post(window.opener, this.request(method, params, this.id), this._origin);
+		this.post(this.parent, this.request(method, params, this.id), this._origin);
 		this.nextID();
 		return promise;
 	}


### PR DESCRIPTION
When you are working with pop-up windows hosted on different domains instead of iframes `window.opener` seems to be the right window reference object to use instead of `window.parent`.

This change should work in both cases, however not tested on iframes